### PR TITLE
Add sort and filter

### DIFF
--- a/app_wine_front/src/components/display-options/index.js
+++ b/app_wine_front/src/components/display-options/index.js
@@ -3,6 +3,7 @@ import {
   Card,
   CardContent,
   CardTitle,
+  FormInput,
   RadioGroup,
 } from 'former-kit'
 import DisplayOptionsContext from '../../contexts/display-options-context'
@@ -39,7 +40,9 @@ const orderByOptions = [
 
 const DisplayOptions = () => {
   const {
+    filterByText,
     orderBy,
+    setFilterByText,
     setOrderBy,
     setSortBy,
     sortBy,
@@ -52,6 +55,8 @@ const DisplayOptions = () => {
     <Card>
       <CardTitle title="Display options" />
       <CardContent>
+        <p>Sort options:</p>
+
         <RadioGroup
           options={sortByOptions}
           name="sortByOptions"
@@ -64,6 +69,15 @@ const DisplayOptions = () => {
           name="orderByOptions"
           onChange={onChangeOrderByHandle}
           value={orderBy}
+        />
+
+        <p>Filter</p>
+
+        <FormInput
+          type="text"
+          label="Show only if contains..."
+          onChange={e => setFilterByText(e.target.value)}
+          value={filterByText}
         />
       </CardContent>
     </Card>

--- a/app_wine_front/src/components/display-options/index.js
+++ b/app_wine_front/src/components/display-options/index.js
@@ -1,0 +1,73 @@
+import React, { useContext } from 'react'
+import {
+  Card,
+  CardContent,
+  CardTitle,
+  RadioGroup,
+} from 'former-kit'
+import DisplayOptionsContext from '../../contexts/display-options-context'
+
+const sortByOptions = [
+  {
+    name: 'Name',
+    value: 'name',
+  },
+  {
+    name: 'Vineyard',
+    value: 'vineyard',
+  },
+  {
+    name: 'Year',
+    value: 'year',
+  },
+  {
+    name: 'Price',
+    value: 'price',
+  },
+]
+
+const orderByOptions = [
+  {
+    name: 'Asc',
+    value: 'asc',
+  },
+  {
+    name: 'Desc',
+    value: 'desc',
+  },
+]
+
+const DisplayOptions = () => {
+  const {
+    orderBy,
+    setOrderBy,
+    setSortBy,
+    sortBy,
+  } = useContext(DisplayOptionsContext)
+
+  const onChangeSortByHandle = event => setSortBy(event.target.value)
+  const onChangeOrderByHandle = event => setOrderBy(event.target.value)
+
+  return (
+    <Card>
+      <CardTitle title="Display options" />
+      <CardContent>
+        <RadioGroup
+          options={sortByOptions}
+          name="sortByOptions"
+          onChange={onChangeSortByHandle}
+          value={sortBy}
+        />
+
+        <RadioGroup
+          options={orderByOptions}
+          name="orderByOptions"
+          onChange={onChangeOrderByHandle}
+          value={orderBy}
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+export default DisplayOptions

--- a/app_wine_front/src/components/wines-list/index.js
+++ b/app_wine_front/src/components/wines-list/index.js
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react'
 import { Card, CardContent } from 'former-kit'
 import ApiContext from '../../contexts/api-context'
+import DisplayOptionsContext from '../../contexts/display-options-context'
 import EmptyState from './empty-state'
 import StartingState from './starting-state'
 import ErrorState from './error-state'
@@ -9,6 +10,7 @@ import style from './style.css'
 
 const WinesList = () => {
   const { winesListState } = useContext(ApiContext)
+  const { sortFunc } = useContext(DisplayOptionsContext)
 
   if (winesListState.status === 'starting') {
     return <StartingState />
@@ -22,18 +24,20 @@ const WinesList = () => {
     return <EmptyState />
   }
 
-  const wines = winesListState.data.map(wine => (
-    <Card key={wine.name} className={style.cardWine}>
-      <CardContent>
-        <WineRow
-          name={wine.name}
-          vineyard={wine.vineyard}
-          year={wine.year}
-          price={wine.price}
-        />
-      </CardContent>
-    </Card>
-  ))
+  const wines = winesListState.data
+    .sort(sortFunc)
+    .map(wine => (
+      <Card key={wine.name} className={style.cardWine}>
+        <CardContent>
+          <WineRow
+            name={wine.name}
+            vineyard={wine.vineyard}
+            year={wine.year}
+            price={wine.price}
+          />
+        </CardContent>
+      </Card>
+    ))
 
   return wines
 }

--- a/app_wine_front/src/components/wines-list/index.js
+++ b/app_wine_front/src/components/wines-list/index.js
@@ -10,7 +10,7 @@ import style from './style.css'
 
 const WinesList = () => {
   const { winesListState } = useContext(ApiContext)
-  const { sortFunc } = useContext(DisplayOptionsContext)
+  const { filterFunc, sortFunc } = useContext(DisplayOptionsContext)
 
   if (winesListState.status === 'starting') {
     return <StartingState />
@@ -20,12 +20,15 @@ const WinesList = () => {
     return <ErrorState />
   }
 
-  if (winesListState.data.length === 0) {
+  const wines = winesListState.data
+    .filter(filterFunc)
+    .sort(sortFunc)
+
+  if (wines.length === 0) {
     return <EmptyState />
   }
 
-  const wines = winesListState.data
-    .sort(sortFunc)
+  const winesRows = wines
     .map(wine => (
       <Card key={wine.name} className={style.cardWine}>
         <CardContent>
@@ -39,7 +42,7 @@ const WinesList = () => {
       </Card>
     ))
 
-  return wines
+  return winesRows
 }
 
 export default WinesList

--- a/app_wine_front/src/contexts/display-options-context.js
+++ b/app_wine_front/src/contexts/display-options-context.js
@@ -1,0 +1,6 @@
+import React from 'react'
+
+// Store the display options (such as order by something) - status and actions
+const DisplayOptionsContext = React.createContext()
+
+export default DisplayOptionsContext

--- a/app_wine_front/src/index.js
+++ b/app_wine_front/src/index.js
@@ -3,12 +3,15 @@ import ReactDOM from 'react-dom'
 import { ThemeProvider } from 'former-kit'
 import skin from 'former-kit-skin-pagarme'
 import ApiProvider from './providers/api-providers'
+import DisplayOptionsProvider from './providers/display-options-provider'
 import Main from './pages/main'
 
 const App = () => (
   <ThemeProvider theme={skin}>
     <ApiProvider>
-      <Main />
+      <DisplayOptionsProvider>
+        <Main />
+      </DisplayOptionsProvider>
     </ApiProvider>
   </ThemeProvider>
 )

--- a/app_wine_front/src/pages/main/index.js
+++ b/app_wine_front/src/pages/main/index.js
@@ -1,11 +1,14 @@
 import React from 'react'
 import AddWine from '../../components/add-wine'
+import DisplayOptions from '../../components/display-options'
 import WinesList from '../../components/wines-list'
 import style from './style.css'
 
 const Main = () => (
   <div className={style.cellsFeatures}>
     <AddWine />
+
+    <DisplayOptions />
 
     <div>
       <WinesList />

--- a/app_wine_front/src/providers/display-options-provider.js
+++ b/app_wine_front/src/providers/display-options-provider.js
@@ -4,11 +4,13 @@ import DisplayOptionsContext from '../contexts/display-options-context'
 
 const DisplayOptionsProvider = ({
   children,
+  filterByText: defaultFilterByText,
   orderBy: defaultOrderBy,
   sortBy: defaultSortBy,
 }) => {
   const [orderBy, setOrderBy] = useState(defaultOrderBy)
   const [sortBy, setSortBy] = useState(defaultSortBy)
+  const [filterByText, setFilterByText] = useState(defaultFilterByText)
 
   const sortFunc = {
     asc: {
@@ -37,10 +39,20 @@ const DisplayOptionsProvider = ({
     },
   }
 
+  const filterFunc = wine => (
+    wine.name.toLocaleUpperCase().includes(filterByText.toLocaleUpperCase())
+    || wine.vineyard.toLocaleUpperCase().includes(
+      filterByText.toLocaleUpperCase()
+    )
+  )
+
   return (
     <DisplayOptionsContext.Provider
       value={{
+        filterByText,
+        filterFunc,
         orderBy,
+        setFilterByText,
         setOrderBy,
         setSortBy,
         sortBy,
@@ -54,11 +66,13 @@ const DisplayOptionsProvider = ({
 
 DisplayOptionsProvider.propTypes = {
   children: PropTypes.node.isRequired,
+  filterByText: PropTypes.string,
   orderBy: PropTypes.string,
   sortBy: PropTypes.string,
 }
 
 DisplayOptionsProvider.defaultProps = {
+  filterByText: '',
   orderBy: 'asc',
   sortBy: 'name',
 }

--- a/app_wine_front/src/providers/display-options-provider.js
+++ b/app_wine_front/src/providers/display-options-provider.js
@@ -1,0 +1,66 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+import DisplayOptionsContext from '../contexts/display-options-context'
+
+const DisplayOptionsProvider = ({
+  children,
+  orderBy: defaultOrderBy,
+  sortBy: defaultSortBy,
+}) => {
+  const [orderBy, setOrderBy] = useState(defaultOrderBy)
+  const [sortBy, setSortBy] = useState(defaultSortBy)
+
+  const sortFunc = {
+    asc: {
+      name: (wineA, wineB) => wineA.name.toLocaleUpperCase().localeCompare(
+        wineB.name.toLocaleUpperCase()
+      ),
+      price: (wineA, wineB) => wineA.price - wineB.price,
+      vineyard: (wineA, wineB) => (
+        wineA.vineyard.toLocaleUpperCase().localeCompare(
+          wineB.vineyard.toLocaleUpperCase()
+        )
+      ),
+      year: (wineA, wineB) => wineA.year - wineB.year,
+    },
+    desc: {
+      name: (wineA, wineB) => wineB.name.toLocaleUpperCase().localeCompare(
+        wineA.name.toLocaleUpperCase()
+      ),
+      price: (wineA, wineB) => wineB.price - wineA.price,
+      vineyard: (wineA, wineB) => (
+        wineB.vineyard.toLocaleUpperCase().localeCompare(
+          wineA.vineyard.toLocaleUpperCase()
+        )
+      ),
+      year: (wineA, wineB) => wineB.year - wineA.year,
+    },
+  }
+
+  return (
+    <DisplayOptionsContext.Provider
+      value={{
+        orderBy,
+        setOrderBy,
+        setSortBy,
+        sortBy,
+        sortFunc: sortFunc[orderBy][sortBy],
+      }}
+    >
+      {children}
+    </DisplayOptionsContext.Provider>
+  )
+}
+
+DisplayOptionsProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+  orderBy: PropTypes.string,
+  sortBy: PropTypes.string,
+}
+
+DisplayOptionsProvider.defaultProps = {
+  orderBy: 'asc',
+  sortBy: 'name',
+}
+
+export default DisplayOptionsProvider

--- a/app_wine_front/tests/unit/components/wines-list.js
+++ b/app_wine_front/tests/unit/components/wines-list.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import test from 'ava'
 import ApiProviderMock from '../../helpers/api-provider-mock'
+import DisplayOptionsProvider from '../../../src/providers/display-options-provider'
 import WinesList from '../../../src/components/wines-list'
 
 test('Component WinesList when is still loading data from server', (t) => {
@@ -12,7 +13,9 @@ test('Component WinesList when is still loading data from server', (t) => {
         status: 'starting',
       }}
     >
-      <WinesList />
+      <DisplayOptionsProvider>
+        <WinesList />
+      </DisplayOptionsProvider>
     </ApiProviderMock>
   )
 
@@ -31,7 +34,9 @@ test('Component WinesList when it fails to load the data from server', (t) => {
         status: 'error',
       }}
     >
-      <WinesList />
+      <DisplayOptionsProvider>
+        <WinesList />
+      </DisplayOptionsProvider>
     </ApiProviderMock>
   )
 
@@ -50,7 +55,9 @@ test('Component WinesList when is empty state', (t) => {
         status: 'loaded',
       }}
     >
-      <WinesList />
+      <DisplayOptionsProvider>
+        <WinesList />
+      </DisplayOptionsProvider>
     </ApiProviderMock>
   )
 
@@ -78,10 +85,102 @@ test('Component WinesList when is filled', (t) => {
         status: 'loaded',
       }}
     >
-      <WinesList />
+      <DisplayOptionsProvider>
+        <WinesList />
+      </DisplayOptionsProvider>
     </ApiProviderMock>
   )
 
   const cardWineElements = container.querySelectorAll('.cardWine')
   t.deepEqual(cardWineElements.length, 1)
+})
+
+test('Component WinesList when is sorting by price asc', (t) => {
+  const winesDataMock = [
+    {
+      name: 'normal',
+      price: 5,
+      vineyard: 'Porto',
+      year: 2019,
+    },
+    {
+      name: 'cheap',
+      price: 1,
+      vineyard: 'Porto',
+      year: 2019,
+    },
+    {
+      name: 'expensive',
+      price: 9,
+      vineyard: 'Porto',
+      year: 2019,
+    },
+  ]
+
+  const { container } = render(
+    <ApiProviderMock
+      winesListState={{
+        data: winesDataMock,
+        status: 'loaded',
+      }}
+    >
+      <DisplayOptionsProvider sortBy="price" orderBy="asc">
+        <WinesList />
+      </DisplayOptionsProvider>
+    </ApiProviderMock>
+  )
+
+  const cardWineElements = container.querySelectorAll('.cardWine')
+  const winesNameElements = container.querySelectorAll('.cardWine button')
+
+  t.deepEqual(cardWineElements.length, 3)
+
+  t.deepEqual(winesNameElements[0].textContent, 'cheap')
+  t.deepEqual(winesNameElements[1].textContent, 'normal')
+  t.deepEqual(winesNameElements[2].textContent, 'expensive')
+})
+
+test('Component WinesList when is sorting by vineyard desc', (t) => {
+  const winesDataMock = [
+    {
+      name: 'should be the last',
+      price: 9,
+      vineyard: 'a',
+      year: 2019,
+    },
+    {
+      name: 'should be the first',
+      price: 5,
+      vineyard: 'z',
+      year: 2019,
+    },
+    {
+      name: 'should be the second',
+      price: 1,
+      vineyard: 'b',
+      year: 2019,
+    },
+  ]
+
+  const { container } = render(
+    <ApiProviderMock
+      winesListState={{
+        data: winesDataMock,
+        status: 'loaded',
+      }}
+    >
+      <DisplayOptionsProvider sortBy="vineyard" orderBy="desc">
+        <WinesList />
+      </DisplayOptionsProvider>
+    </ApiProviderMock>
+  )
+
+  const cardWineElements = container.querySelectorAll('.cardWine')
+  const winesNameElements = container.querySelectorAll('.cardWine button')
+
+  t.deepEqual(cardWineElements.length, 3)
+
+  t.deepEqual(winesNameElements[0].textContent, 'should be the first')
+  t.deepEqual(winesNameElements[1].textContent, 'should be the second')
+  t.deepEqual(winesNameElements[2].textContent, 'should be the last')
 })

--- a/app_wine_front/tests/unit/components/wines-list.js
+++ b/app_wine_front/tests/unit/components/wines-list.js
@@ -184,3 +184,42 @@ test('Component WinesList when is sorting by vineyard desc', (t) => {
   t.deepEqual(winesNameElements[1].textContent, 'should be the second')
   t.deepEqual(winesNameElements[2].textContent, 'should be the last')
 })
+
+test('Component WinesList when is filtering', (t) => {
+  const winesDataMock = [
+    {
+      name: 'cheap wine from portugal',
+      price: 100,
+      vineyard: 'lisboa',
+      year: 2019,
+    },
+    {
+      name: 'expensive wine from portugal',
+      price: 500000,
+      vineyard: 'porto',
+      year: 2019,
+    },
+    {
+      name: 'wine from uk',
+      price: 3232,
+      vineyard: 'london',
+      year: 2019,
+    },
+  ]
+
+  const { container } = render(
+    <ApiProviderMock
+      winesListState={{
+        data: winesDataMock,
+        status: 'loaded',
+      }}
+    >
+      <DisplayOptionsProvider filterByText="portugal">
+        <WinesList />
+      </DisplayOptionsProvider>
+    </ApiProviderMock>
+  )
+
+  const cardWineElements = container.querySelectorAll('.cardWine')
+  t.deepEqual(cardWineElements.length, 2)
+})


### PR DESCRIPTION
Add sort and filter features on the front-end. To do it, was add the new provider `DisplayOptionsProvider`.

![image](https://user-images.githubusercontent.com/9501115/68094337-53259700-fe97-11e9-93ba-87bab78d0ee6.png)
